### PR TITLE
explicitly tags configuration and code sections of javascript

### DIFF
--- a/app/assets/javascripts/pages.js
+++ b/app/assets/javascripts/pages.js
@@ -1,6 +1,23 @@
+////////////////////
+// Configurations //
+////////////////////
+
+// Point this to the endpoint that serves the graph data for a given Stock Ticker
+// {{id}} is a place holder for integer
 var graph_data_uri = "/stock_tickers/{{id}}/graph_data.json";
+
+// To render the chart to the DOM, you need to place a chart div in the markup
+// with the id defined below
 var id_of_chart_div = "chart1";
+
+// chart1 is an object of type Chartkick.LineChart.  It's exposed as a global
+// to facilitate testing via capybara.
 var chart1;
+
+
+///////////
+// Code  //
+///////////
 
 $(function() {
   $('#Stock_Tickers').on('change', function() {

--- a/app/assets/javascripts/pages.js
+++ b/app/assets/javascripts/pages.js
@@ -1,6 +1,8 @@
-////////////////////
-// Configurations //
-////////////////////
+// FIXME: convert to a class/ prototype pattern
+
+/*******************
+ *  Configurations *
+ *******************/
 
 // Point this to the endpoint that serves the graph data for a given Stock Ticker
 // {{id}} is a place holder for integer
@@ -15,9 +17,9 @@ var id_of_chart_div = "chart1";
 var chart1;
 
 
-///////////
-// Code  //
-///////////
+/****************
+ *     Code     *
+ ****************/
 
 $(function() {
   $('#Stock_Tickers').on('change', function() {


### PR DESCRIPTION
Sometimes people interacting with the markup can break my javascript if it's unclear what my script depends upon.  Likewise, people on the backend can modify endpoints and such, which breaks my js.  To conserve developer time, I like to explicitly mark what my js depends on so that when someone does want to change it, they can easily see how to put things right again.  Though admittedly this bit of javascript lacks the complexity to actually require a discrete configuration section.  

Also I haven't wrapped it all up into a single object to minimize contact with the global namespace... I'm still cleaning up my websockets branch.  
